### PR TITLE
Readme update - fix for csc.exe not found runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ The files will copy over after you build the ImageFilter.Web project.
 ## To see your changes reflected in the backoffice
 
 For best results, I have found it is best to use a private browser session, increment the ClientDependency.config version number and have dev tools open so you can right click on the reload button and choose "Empty Cache and Hard Reload"
+
+## Issues with Rosyln Compiler ##
+
+When running the project for the first time you may get a runtime error stating that csc.exe could not be found. To resolve this a nuget package needs to be reinstalled. Use the following command to fix this issue:
+
+`Update-package Microsoft.CodeDom.Providers.DotNetCompilerPlatform -r`


### PR DESCRIPTION
Additional read-me information on how to fix YSOD runtime error where csc.exe roslyn compiler is not found.